### PR TITLE
feat: implement logout API

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { UsersService } from './users.service';
@@ -13,5 +13,12 @@ export class UsersController {
     // The payload sub usually contains the user ID
     const userId = user.sub;
     return this.usersService.getCurrentUser(userId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('logout')
+  async logout(@CurrentUser() user: any) {
+    const userId = user.sub;
+    return this.usersService.logout(userId);
   }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, UseGuards, HttpCode, HttpStatus } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { UsersService } from './users.service';
@@ -17,6 +17,7 @@ export class UsersController {
 
   @UseGuards(JwtAuthGuard)
   @Post('logout')
+  @HttpCode(HttpStatus.OK)
   async logout(@CurrentUser() user: any) {
     const userId = user.sub;
     return this.usersService.logout(userId);

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,9 +1,14 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, Inject } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class UsersService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+  ) {}
 
   async getCurrentUser(userId: string) {
     const user = await this.prisma.user.findUnique({
@@ -22,5 +27,12 @@ export class UsersService {
     }
 
     return user;
+  }
+
+  async logout(userId: string) {
+    const sessionKey = `auth:token:${userId}`;
+    await this.cacheManager.del(sessionKey);
+
+    return { message: 'Logout success' };
   }
 }


### PR DESCRIPTION
This PR implements the Logout API endpoint. It invalidates the user's session by removing the JWT token from the Redis whitelist. Fixes #9.